### PR TITLE
Pin OpenJDK to version 8

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 99f492903a9abe03056867d3e098917bdb1baf3ddf2fa56b6fa243d93c219ccf
 
 build:
-  number: 1000
+  number: 1001
   script: "{{ PYTHON }} -m pip install . -vvv  --no-deps"
   skip: True  # [py2k]
 
@@ -27,6 +27,7 @@ requirements:
     - pyjnius
     - scyjava
     - maven
+    - openjdk =8
 
 test:
   imports:


### PR DESCRIPTION
I tried to run the imglyb examples with openjdk 10 and 11 from conda-forge but I saw this exception:
```
$ imglyb-examples.butterfly
Traceback (most recent call last):
  File "/home/hanslovskyp/miniconda3/envs/imglyb-scipy/bin/imglyb-examples.butterfly", line 6, in <module>
    from imglyb_examples.butterfly import main
  File "/home/hanslovskyp/miniconda3/envs/imglyb-scipy/lib/python3.7/site-packages/imglyb_examples/butterfly.py", line 2, in <module>
    import imglyb
  File "/home/hanslovskyp/.local/lib/python3.7/site-packages/imglyb/__init__.py", line 38, in <module>
    config, _ = _init_jvm_options()
  File "/home/hanslovskyp/.local/lib/python3.7/site-packages/imglyb/__init__.py", line 33, in _init_jvm_options
    import scyjava
  File "/home/hanslovskyp/.local/lib/python3.7/site-packages/scyjava/__init__.py", line 55, in <module>
    jnius = _init_jvm()
  File "/home/hanslovskyp/.local/lib/python3.7/site-packages/scyjava/__init__.py", line 46, in _init_jvm
    import jnius
  File "/home/hanslovskyp/.local/lib/python3.7/site-packages/jnius/__init__.py", line 13, in <module>
    from .reflect import *  # noqa
  File "/home/hanslovskyp/.local/lib/python3.7/site-packages/jnius/reflect.py", line 15, in <module>
    class Class(with_metaclass(MetaJavaClass, JavaClass)):
  File "/home/hanslovskyp/miniconda3/envs/imglyb-scipy/lib/python3.7/site-packages/six.py", line 827, in __new__
    return meta(name, bases, d)
  File "jnius/jnius_export_class.pxi", line 114, in jnius.MetaJavaClass.__new__
  File "jnius/jnius_export_class.pxi", line 164, in jnius.MetaJavaClass.resolve_class
  File "jnius/jnius_env.pxi", line 11, in jnius.get_jnienv
  File "jnius/jnius_jvm_dlopen.pxi", line 90, in jnius.get_platform_jnienv
  File "jnius/jnius_jvm_dlopen.pxi", line 59, in jnius.create_jnienv
SystemError: Error calling dlopen(b'/home/hanslovskyp/miniconda3/envs/imglyb-scipy/jre/lib/amd64/server/libjvm.so': b'/home/hanslovskyp/miniconda3/envs/imglyb-scipy/jre/lib/amd64/server/libjvm.so: cannot open shared object file: No such file or directory'
```

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
